### PR TITLE
Hotfixes/docker tags

### DIFF
--- a/.github/workflows/docker-build-push-image.yml
+++ b/.github/workflows/docker-build-push-image.yml
@@ -67,7 +67,7 @@ jobs:
 
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=raw,value=latest,suffix=${{ env.IMG_TAG_SUFFIX }}
+          type=raw,value=gh-test,suffix=${{ env.IMG_TAG_SUFFIX }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-build-push-image.yml
+++ b/.github/workflows/docker-build-push-image.yml
@@ -63,7 +63,7 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         # list of Docker images to use as base name for tags
-        images: ${{ inputs.image_repository }}
+        images: ${{ inputs.registry_server }}/${{ inputs.image_repository }}
 
         # generate Docker tags based on the following events/attributes
         tags: |


### PR DESCRIPTION
As we don't use the `docker.io` registry to push image, we have to specify the registry server on image name.